### PR TITLE
Fully initialize SPI device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 pynrf24
 =======
 
-Python port of the RF24 (https://github.com/maniacbug/RF24/) library for NRF24L01+ radios, adapted for the BeagleBone Black and the Raspberry Pi.
-
-All methods were ported and most methods prototypes were kept similar. This should facilitate the adaptation of existing code.
-Limitations were also ported and unfortunately some bugs may have been introduced.
+Python port of the RF24 (https://github.com/maniacbug/RF24/) library for NRF24L01+ radios, adapted for the BeagleBone Black, the Banana Pi and the Raspberry Pi.
 
 For more information regarding how to use this library, check the RF24 documentation: http://maniacbug.github.io/RF24/
 Most of the information there will also be valid to this library.
 
-Tested in a BeagleBoneBlack using spi0 and NRF24L01+ radios.
+Tested in a Banana Pi using spi0 and NRF24L01+ radios.
 Should work without problems in a Raspberry Pi or with NRF24L01 (non +) radios.
 
 Do not forget to check this [great tutorial](http://www.diyembedded.com/tutorials/nrf24l01_0/nrf24l01_tutorial_0.pdf)
 or the [original datasheet](http://www.nordicsemi.com/eng/Products/2.4GHz-RF/nRF24L01)
 
 
+Note
+----
+This library uses a different convention of mac adresses compared to the original library.
+The byte order is _NOT_ reversed before sending it to the NRF24L01.
+
 Contact
 -------
 
-For any information regarding this library you can contact me at jpbarraca at gmail.
+For any information regarding this library you can open tickets on Github.
 
 Improvements to the code base are also welcome.
 
@@ -31,7 +33,7 @@ Requirements
  * SPI communication requires spidev:  https://pypi.python.org/pypi/spidev
  * BBB: GPIO access requires Adafruit BBIO library: https://github.com/adafruit/adafruit-beaglebone-io-python
  * BBB: If using GPIO IRQ detection, a custom version of the Adafruit library must be used https://github.com/jpbarraca/adafruit-beaglebone-io-python . A patch was already submitted to Adafruit.
- 
+
 
 Wiring
 ------
@@ -52,40 +54,35 @@ Examples
 
 Initialization:
 
-		pipes = [ [0xe7, 0xe7, 0xe7, 0xe7, 0xe7], [0xc2, 0xc2, 0xc2, 0xc2, 0xc2] ]
-
-		radio = NRF24()
-		radio.begin(1,0,"P9_15", "P9_16") #Set CE and IRQ pins
-		radio.setRetries(15,15)
-		radio.setPayloadSize(8)
-		radio.setChannel(0x60)
-		radio.setDataRate(NRF24.BR_250KBPS)
-		radio.setPALevel(NRF24.PA_MAX)
-		radio.openWritingPipe(pipes[0])
-		radio.openReadingPipe(1,pipes[1])
-
-		radio.printDetails()
+    mac = "TEST1" # or mac = [0xe7, 0xe7, 0xe7, 0xe7, 0xe7]
+    radio = NRF24(spi=(0,0), ce_pin="P9_15", irq_pin="P9_16")
+    radio.data_rate = 2000 #kbps
+    radio.crc_length = 2 #bytes
+    radio.channel = 0x60
+    radio.dbm = 0
+    radio.enable_dynamic_payloads()
+    # or
+    radio.set_auto_ack(1)
+    radio.open_writing_pipe(mac)
+    radio.open_reading_pipe(0, mac)
+    radio.print_details()
 
 
 Sending Data:
 
-    buffer = ['H','E','L','L','O']
-    status = radio.write(buffer)
+    status = radio.write("HELLO")
+    #or
+    status = radio.write(['H','E','L','L','O'])
 
 
 Receiving Data:
 
-	#Wait for data
-	pipe =[0]
-	while not radio.available(pipe):
-		time.sleep(10000/1000000.0)
+    #Wait for data
+    pipe = [0]
+    while not radio.available(pipe):
+        time.sleep(0.01)
 
-	#Receive Data
-	recv_buffer = []
-    radio.read(recv_buffer)
-
-	#Print the buffer
-	print recv_buffer
+    print radio.read(recv_buffer)
 
 
 Caveats

--- a/nrf24.py
+++ b/nrf24.py
@@ -370,6 +370,17 @@ class NRF24:
         # Initialize SPI bus
         self.spidev = spidev.SpiDev()
         self.spidev.open(major, minor)
+        self.spidev.bits_per_word = 8
+        self.spidev.cshigh = False
+        self.spidev.loop = False
+        self.spidev.lsbfirst = False
+        try:
+            self.spidev.max_speed_hz = 10000000 #Maximum supported by NRF24L01+
+        except IOError:
+            pass # Hardware does not support this speed
+        self.spidev.mode = 0
+        self.spidev.threewire = False
+        
         self.ce_pin = ce_pin
         self.irq_pin = irq_pin
 

--- a/nrf24.py
+++ b/nrf24.py
@@ -13,10 +13,7 @@
 #
 # Python port of Maniacbug NRF24L01 library
 # Author: Joao Paulo Barraca <jpbarraca@gmail.com>
-#
-# BeagleBoneBlack and Raspberry Pi use different GPIO access methods.
-# Select the most appropriate for you by uncommenting one of the
-# two imports.
+
 
 try:
     #For BBBB
@@ -28,6 +25,12 @@ except ImportError:
     except ImportError:
         raise ImportError('Neither RPi.GPIO nor Adafruit_BBIO.GPIO module found.')
 
+# Use a monotonic clock if available to avoid unwanted side effects from clock
+# changes
+try:
+    from time import monotonic
+except ImportError:
+    from time import time as monotonic
 
 import spidev
 import time
@@ -36,31 +39,9 @@ if sys.version > '3':
     long = int
 
 
-def _BV(x):
-    return 1 << x
-
-
-class NRF24:
+class NRF24(object):
     MAX_CHANNEL = 127
     MAX_PAYLOAD_SIZE = 32
-
-    # PA Levels
-    PA_MIN = 0
-    PA_LOW = 1
-    PA_HIGH = 2
-    PA_MAX = 3
-    PA_ERROR = 4
-
-    # Bit rates
-    BR_1MBPS = 0
-    BR_2MBPS = 1
-    BR_250KBPS = 2
-
-    # CRC
-    CRC_DISABLED = 0
-    CRC_8 = 1
-    CRC_16 = 2
-    CRC_ENABLED = 3
 
     # Registers
     CONFIG = 0x00
@@ -91,52 +72,33 @@ class NRF24:
     FEATURE = 0x1D
 
     # Bit Mnemonics */
-    MASK_RX_DR = 6
-    MASK_TX_DS = 5
-    MASK_MAX_RT = 4
-    EN_CRC = 3
-    CRCO = 2
-    PWR_UP = 1
-    PRIM_RX = 0
-    ENAA_P5 = 5
-    ENAA_P4 = 4
-    ENAA_P3 = 3
-    ENAA_P2 = 2
-    ENAA_P1 = 1
-    ENAA_P0 = 0
-    ERX_P5 = 5
-    ERX_P4 = 4
-    ERX_P3 = 3
-    ERX_P2 = 2
-    ERX_P1 = 1
-    ERX_P0 = 0
-    AW = 0
-    ARD = 4
-    ARC = 0
-    PLL_LOCK = 4
-    RF_DR = 3
-    RF_PWR = 6
-    RX_DR = 6
-    TX_DS = 5
-    MAX_RT = 4
-    RX_P_NO = 1
-    TX_FULL = 0
-    PLOS_CNT = 4
-    ARC_CNT = 0
+    MASK_RX_DR = 0x40
+    MASK_TX_DS = 0x20
+    MASK_MAX_RT = 0x10
+    EN_CRC = 0x08
+    CRCO = 0x04
+    PWR_UP = 0x02
+    PRIM_RX = 0x01
+    PLL_LOCK = 0x10
+    RX_DR = 0x40
+    TX_DS = 0x20
+    MAX_RT = 0x10
+    TX_FULL = 0x01
     TX_REUSE = 6
     FIFO_FULL = 5
     TX_EMPTY = 4
     RX_FULL = 1
     RX_EMPTY = 0
-    DPL_P5 = 5
-    DPL_P4 = 4
-    DPL_P3 = 3
-    DPL_P2 = 2
-    DPL_P1 = 1
-    DPL_P0 = 0
-    EN_DPL = 2
-    EN_ACK_PAY = 1
-    EN_DYN_ACK = 0
+    EN_DPL = 0x04
+    EN_ACK_PAY = 0x02
+    EN_DYN_ACK = 0x01
+
+    # Shift counts
+    ARD = 4
+    ARC = 0
+    PLOS_CNT = 4
+    ARC_CNT = 0
+    RX_P_NO = 1
 
     # Instruction Mnemonics
     R_REGISTER = 0x00
@@ -159,215 +121,34 @@ class NRF24:
     RPD = 0x09
 
     # P model bit Mnemonics
-    RF_DR_LOW = 5
-    RF_DR_HIGH = 3
-    RF_PWR_LOW = 1
-    RF_PWR_HIGH = 2
+    RF_DR_LOW = 0x20
+    RF_DR_HIGH = 0x08
 
-    # Signal Mnemonics
-    LOW = 0
-    HIGH = 1
+    RF_PWR_LOW = 0x02
+    RF_PWR_HIGH = 0x04
 
-    datarate_e_str_P = ["1MBPS", "2MBPS", "250KBPS"]
     model_e_str_P = ["nRF24L01", "nRF24l01+"]
-    crclength_e_str_P = ["Disabled", "8 bits", "16 bits"]
-    pa_dbm_e_str_P = ["PA_MIN", "PA_LOW", "PA_MED", "PA_HIGH"]
-    child_pipe = [RX_ADDR_P0, RX_ADDR_P1, RX_ADDR_P2, RX_ADDR_P3, RX_ADDR_P4, RX_ADDR_P5]
 
-    child_payload_size = [RX_PW_P0, RX_PW_P1, RX_PW_P2, RX_PW_P3, RX_PW_P4, RX_PW_P5]
-    child_pipe_enable = [ERX_P0, ERX_P1, ERX_P2, ERX_P3, ERX_P4, ERX_P5]
 
-    def __init__(self):
-        self.ce_pin = "P9_15"
-        self.irq_pin = "P9_16"
-        self.channel = 76
-        self.data_rate = NRF24.BR_1MBPS
-        self.data_rate_bits = 1000
-        self.p_variant = False  # False for RF24L01 and true for RF24L01P
-        self.payload_size = 5  # *< Fixed size of payloads
-        self.ack_payload_available = False  # *< Whether there is an ack payload waiting
-        self.dynamic_payloads_enabled = False  # *< Whether dynamic payloads are enabled.
-        self.ack_payload_length = 5  # *< Dynamic size of pending ack payload.
-        self.pipe0_reading_address = None  # *< Last address set on pipe 0 for reading.
-        self.spidev = None
-        self.using_adafruit_bbio_gpio = GPIO.__name__ == "Adafruit_BBIO.GPIO"
-
-    def ce(self, level):
-        if level == NRF24.HIGH:
-            GPIO.output(self.ce_pin, GPIO.HIGH)
+    @staticmethod
+    def _to_8b_list(data):
+        """Convert an arbitray iteratable or single int to a list of ints
+            where each int is smaller than 256."""
+        if isinstance(data, (int, long)):
+            data = [data]
+        elif isinstance(data, str):
+            data = [ord(x) for x in data]
         else:
-            GPIO.output(self.ce_pin, GPIO.LOW)
-        return
+            data = [int(x) for x in data]
 
-    def irqWait(self, timeout = 30000):
-        # CHANGE: detect module name because wait_for_edge is not available in
-        # other libraries
-        if not self.using_adafruit_bbio_gpio:
-            raise Exception("IRQ Wait only available on the BBB")
+        for byte in data:
+            if byte < 0 or byte > 255:
+                raise RuntimeError("Value %d is larger than 8 bits" % byte)
+        return data
 
-        # TODO: A race condition may occur here.
-        if GPIO.input(self.irq_pin) == 0:  # Pin is already down. Packet is waiting?
-            return True
 
-        #HACK to detect GPIO lib type
-        if GPIO.wait_for_edge.func_code.co_argcount == 4:
-            return GPIO.wait_for_edge(self.irq_pin, GPIO.FALLING, timeout) == 1
-        else:
-            return GPIO.wait_for_edge(self.irq_pin, GPIO.FALLING) == 1
-
-    def read_register(self, reg, blen=1):
-        buf = [NRF24.R_REGISTER | (NRF24.REGISTER_MASK & reg)]
-        buf += [NRF24.NOP] * max(1, blen)
-
-        resp = self.spidev.xfer2(buf)
-        if blen == 1:
-            return resp[1]
-
-        return resp[1:]
-
-    def write_register(self, reg, value, length=-1):
-        buf = [NRF24.W_REGISTER | (NRF24.REGISTER_MASK & reg)]
-
-        if isinstance(value, (int, long)):
-            if length < 0:
-                length = 1
-            else:
-                length = min(4, length)
-
-            i = length
-            while i > 0:
-                buf += [int(value & 0xff)]
-                value >>= 8
-                i -= 1
-
-        elif isinstance(value, list):
-            if length < 0:
-                length = len(value)
-
-            for i in range(min(len(value), length)):
-                buf.append(int(value[len(value) - i - 1] & 0xff))
-        else:
-            raise Exception("Value must be int or list")
-
-        return self.spidev.xfer2(buf)[0]
-
-    def write_payload(self, buf):
-        data_len = min(self.payload_size, len(buf))
-        blank_len = 0
-
-        if not self.dynamic_payloads_enabled:
-            blank_len = self.payload_size - data_len
-
-        txbuffer = [NRF24.W_TX_PAYLOAD]
-        for n in buf:
-            t = type(n)
-            if t is str:
-                txbuffer += [ord(n)]
-            elif t is int:
-                txbuffer += [n]
-            else:
-                raise Exception("Only ints and chars are supported: Found " + str(t))
-
-        if blank_len != 0:
-            txbuffer += [0x00] * blank_len
-
-        return self.spidev.xfer2(txbuffer)
-
-    def read_payload(self, buf, buf_len=-1):
-        if buf_len < 0:
-            buf_len = self.payload_size
-
-        data_len = min(self.payload_size, buf_len)
-        blank_len = 0
-
-        if not self.dynamic_payloads_enabled:
-            blank_len = self.payload_size - data_len
-
-        txbuffer = [NRF24.NOP] * (blank_len + data_len + 1)
-        txbuffer[0] = NRF24.R_RX_PAYLOAD
-
-        payload = self.spidev.xfer2(txbuffer)
-        del buf[:]
-        buf.extend(payload[1:data_len + 1])
-
-        return data_len
-
-    def flush_rx(self):
-        return self.spidev.xfer2([NRF24.FLUSH_RX])[0]
-
-    def flush_tx(self):
-        return self.spidev.xfer2([NRF24.FLUSH_TX])[0]
-
-    def get_status(self):
-        return self.spidev.xfer2([NRF24.NOP])[0]
-
-    def print_single_status_line(self, name, value):
-        print("{0:<16}= {1}".format(name, value))
-
-    def print_status(self, status):
-        status_str = "0x{0:02x} RX_DR={1:x} TX_DS={2:x} MAX_RT={3:x} RX_P_NO={4:x} TX_FULL={5:x}".format(
-            status,
-            1 if status & _BV(NRF24.RX_DR) else 0,
-            1 if status & _BV(NRF24.TX_DS) else 0,
-            1 if status & _BV(NRF24.MAX_RT) else 0,
-            ((status >> NRF24.RX_P_NO) & int("111", 2)),
-            1 if status & _BV(NRF24.TX_FULL) else 0)
-
-        self.print_single_status_line("STATUS", status_str)
-
-    def print_observe_tx(self, value):
-        tx_str = "OBSERVE_TX=0x{0:02x}: POLS_CNT={2:x} ARC_CNT={2:x}\r\n".format(
-            value,
-            (value >> NRF24.PLOS_CNT) & int("1111", 2),
-            (value >> NRF24.ARC_CNT) & int("1111", 2))
-
-        print(tx_str)
-
-    def print_byte_register(self, name, reg, qty=1):
-        registers = ["0x{:0>2x}".format(self.read_register(reg+r)) for r in range(0, qty)]
-        self.print_single_status_line(name, " ".join(registers))
-
-    def print_address_register(self, name, reg, qty=1):
-        address_registers = ["0x{4:>2x}{3:>2x}{2:>2x}{1:>2x}{0:>2x}".format(
-            *self.read_register(reg+r, 5))
-            for r in range(0, qty)]
-
-        self.print_single_status_line(name, " ".join(address_registers))
-
-    def setChannel(self, channel):
-        self.channel = min(max(0, channel), NRF24.MAX_CHANNEL)
-        self.write_register(NRF24.RF_CH, self.channel)
-
-    def getChannel(self):
-        return self.read_register(NRF24.RF_CH)
-
-    def setPayloadSize(self, size):
-        self.payload_size = min(max(size, 1), NRF24.MAX_PAYLOAD_SIZE)
-
-    def getPayloadSize(self):
-        return self.payload_size
-
-    def printDetails(self):
-        self.print_status(self.get_status())
-        self.print_address_register("RX_ADDR_P0-1", NRF24.RX_ADDR_P0, 2)
-        self.print_byte_register("RX_ADDR_P2-5", NRF24.RX_ADDR_P2, 4)
-        self.print_address_register("TX_ADDR", NRF24.TX_ADDR)
-
-        self.print_byte_register("RX_PW_P0-6", NRF24.RX_PW_P0, 6)
-        self.print_byte_register("EN_AA", NRF24.EN_AA)
-        self.print_byte_register("EN_RXADDR", NRF24.EN_RXADDR)
-        self.print_byte_register("RF_CH", NRF24.RF_CH)
-        self.print_byte_register("RF_SETUP", NRF24.RF_SETUP)
-        self.print_byte_register("CONFIG", NRF24.CONFIG)
-        self.print_byte_register("DYNPD/FEATURE", NRF24.DYNPD, 2)
-
-        self.print_single_status_line("Data Rate", NRF24.datarate_e_str_P[self.getDataRate()])
-        self.print_single_status_line("Model", NRF24.model_e_str_P[self.isPVariant()])
-        self.print_single_status_line("CRC Length", NRF24.crclength_e_str_P[self.getCRCLength()])
-        self.print_single_status_line("PA Power", NRF24.pa_dbm_e_str_P[self.getPALevel()])
-
-    def begin(self, major, minor, ce_pin, irq_pin):
-        # Initialize SPI bus
+    def __init__(self, major, minor, ce_pin, irq_pin=None):
+        # Init spi
         self.spidev = spidev.SpiDev()
         self.spidev.open(major, minor)
         self.spidev.bits_per_word = 8
@@ -377,154 +158,303 @@ class NRF24:
         try:
             self.spidev.max_speed_hz = 10000000 #Maximum supported by NRF24L01+
         except IOError:
-            pass # Hardware does not support this speed
+            pass # Hardware does not support this speed, use default speed instead
         self.spidev.mode = 0
         self.spidev.threewire = False
-        
+
+
         self.ce_pin = ce_pin
         self.irq_pin = irq_pin
 
         GPIO.setup(self.ce_pin, GPIO.OUT)
-        GPIO.setup(self.irq_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        if self.irq_pin is not None:
+            GPIO.setup(self.irq_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-        time.sleep(5 / 1000000.0)
+        self.reset()
+        self.power_up()
 
-        # Set 1500uS (minimum for 32B payload in ESB@250KBPS) timeouts, to make testing a little easier
-        # WARNING: If this is ever lowered, either 250KBS mode with AA is broken or maximum packet
-        # sizes must never be used. See documentation for a more complete explanation.
-        self.setRetries(int('0101', 2), 15)
+        # Set 1500uS (minimum for 32B payload in ESB@250KBPS) timeouts, to
+        # make testing a little easier
+        # WARNING: If this is ever lowered, either 250KBS mode with AA is
+        # broken or maximum packet sizes must never be used. See documentation
+        # for a more complete explanation.
+        self.delay = None # *< Delay between retransmissions
+        self.retries_cached = None
+        self.set_retries(4000, 15)
 
         # Restore our default PA level
-        self.setPALevel(NRF24.PA_MAX)
+        self.dbm = 0
 
         # Determine if this is a p or non-p RF24 module and then
         # reset our data rate back to default value. This works
         # because a non-P variant won't allow the data rate to
         # be set to 250Kbps.
-        if self.setDataRate(NRF24.BR_250KBPS):
+        try:
+            self.data_rate = 250
             self.p_variant = True
+        except RuntimeError:
+            self.p_variant = False
 
-        # Then set the data rate to the slowest (and most reliable) speed supported by all
-        # hardware.
-        self.setDataRate(NRF24.BR_1MBPS)
-
-        # Initialize CRC and request 2-byte (16bit) CRC
-        self.setCRCLength(NRF24.CRC_16)
+        # Don't set defaults for critical values to avoid users relying on
+        # these values
+        self.data_rate_cached = None
+        self.channel_cached = None
+        self.crc_length_cached = None
+        self.payload_size_cached = None
 
         # Disable dynamic payloads, to match dynamic_payloads_enabled setting
         self.write_register(NRF24.DYNPD, 0)
+        self.dynamic_payloads_enabled = False  # *< Whether dynamic payloads are enabled.
 
         # Reset current status
         # Notice reset and flush is the last thing we do
-        self.write_register(NRF24.STATUS, _BV(NRF24.RX_DR) | _BV(NRF24.TX_DS) | _BV(NRF24.MAX_RT))
-
-        # Set up default configuration.  Callers can always change it later.
-        # This channel should be universally safe and not bleed over into adjacent
-        # spectrum.
-        self.setChannel(self.channel)
-
-        self.setRetries(15, 15)
+        self.clear_irq_flags()
 
         # Flush buffers
         self.flush_rx()
         self.flush_tx()
 
-    def end(self):
-        if self.spidev:
-            self.spidev.close()
-            self.spidev = None
 
-    def startListening(self):
-        self.write_register(NRF24.CONFIG, self.read_register(NRF24.CONFIG) | _BV(NRF24.PWR_UP) | _BV(NRF24.PRIM_RX))
-        self.write_register(NRF24.STATUS, _BV(NRF24.RX_DR) | _BV(NRF24.TX_DS) | _BV(NRF24.MAX_RT))
+        #self.ack_payload_available = False  # *< Whether there is an ack payload waiting
+        #self.ack_payload_length = 5  # *< Dynamic size of pending ack payload.
+        self.pipe0_reading_address = None  # *< Last address set on pipe 0 for reading.
+
+
+    def end(self):
+        self.set_ce(0)
+        self.spidev.close()
+        self.spidev = None
+
+    def reset(self):
+        """ Make sure the NRF is in the same state as after power up
+            to avoid problems resulting from left over configuration
+            from other programs."""
+        self.set_ce(0)
+        reset_values = {0: 0x08, 1: 0x3F, 2:0x03, 3:0x03, 4:0x03, 5:0x02, 6:0x0E,
+                        0x0a: [0xe7, 0xe7, 0xe7, 0xe7, 0xe7],
+                        0x0b: [0xc2, 0xc2, 0xc2, 0xc2, 0xc2],
+                        0x0c: 0xc3, 0x0d:0xc4, 0x0e:0xc5, 0x0f:0xc6,
+                        0x10: [0xe7, 0xe7, 0xe7, 0xe7, 0xe7],
+                        0x11: 0, 0x12:0, 0x13:0, 0x14: 0, 0x15: 0, 0x16: 0,
+                        0x1c: 0, 0x1d:0}
+        for reg, value in reset_values.items():
+            self.write_register(reg, value)
+        self.flush_rx()
+        self.flush_tx()
+
+
+    def set_ce(self, level):
+        GPIO.output(self.ce_pin, level)
+
+    def irq_wait(self, timeout=30000):
+        # TODO: A race condition may occur here. => wait for level?
+        if GPIO.input(self.irq_pin) == 0:  # Pin is already down. Packet is waiting?
+            return True
+
+        try:
+            return GPIO.wait_for_edge(self.irq_pin, GPIO.FALLING, timeout) == 1
+        except TypeError: # Timeout parameter not supported
+            return GPIO.wait_for_edge(self.irq_pin, GPIO.FALLING) == 1
+        except AttributeError:
+            raise RuntimeError("GPIO lib does not support wait_for_edge()")
+
+    def read_register(self, reg, length=1):
+        """Read a register. Returns value as int or list depending on length."""
+        buf = [NRF24.R_REGISTER | (NRF24.REGISTER_MASK & reg)]
+        buf += [NRF24.NOP] * max(1, length)
+
+        resp = self.spidev.xfer2(buf)
+        if length == 1:
+            return resp[1]
+
+        return resp[1:]
+
+    def write_register(self, reg, value):
+        """ Write register value """
+        buf = [NRF24.W_REGISTER | (NRF24.REGISTER_MASK & reg)]
+        buf += self._to_8b_list(value)
+        self.spidev.xfer2(buf)
+
+    def write_payload(self, buf):
+        """ Writes data to the payload register, automatically padding it
+            to match the required length. Returns the number of bytes
+            actually written. """
+        buf = self._to_8b_list(buf)
+        if self.dynamic_payloads_enabled:
+            if len(buf) > self.MAX_PAYLOAD_SIZE:
+                raise RuntimeError("Dynamic payload is larger than the "+
+                    "maximum size.")
+            blank_len = 0
+        else:
+            if len(buf) > self.payload_size:
+                raise RuntimeError("Payload is larger than the fixed payload" +
+                    "size (%d vs. %d bytes)" % (len(buf), self.payload_size))
+            blank_len = self.payload_size - len(buf)
+
+        txbuffer = [NRF24.W_TX_PAYLOAD] + buf + ([0x00] * blank_len)
+
+        self.spidev.xfer2(txbuffer)
+        return len(txbuffer) - 1
+
+    def read(self):
+        if self.dynamic_payloads_enabled:
+            buf_len = self.dynamic_payload_size()
+            if buf_len > 32:
+                print("Warning: Invalid packet length", buf_len)
+                self.flush_rx()
+                return None
+        else:
+            buf_len = self.payload_size
+
+        payload = self.spidev.xfer2([NRF24.R_RX_PAYLOAD] + [NRF24.NOP] * buf_len)
+        return payload[1:buf_len + 1]
+
+    def clear_irq_flags(self):
+        self.write_register(NRF24.STATUS, NRF24.RX_DR | NRF24.TX_DS | NRF24.MAX_RT)
+
+    def flush_rx(self):
+        return self.spidev.xfer2([NRF24.FLUSH_RX])[0]
+
+    def flush_tx(self):
+        return self.spidev.xfer2([NRF24.FLUSH_TX])[0]
+
+    def status(self):
+        return self.spidev.xfer2([NRF24.NOP])[0]
+
+    @staticmethod
+    def print_single_status_line(name, value):
+        print("{0:<16}= {1}".format(name, value))
+
+    def print_status(self, status=None):
+        if status is None:
+            status = self.status()
+        status_str = "0x{0:02x}: RX_DR={1:x} TX_DS={2:x} MAX_RT={3:x} RX_P_NO={4:x} TX_FULL={5:x}".format(
+            status,
+            1 if status & NRF24.RX_DR else 0,
+            1 if status & NRF24.TX_DS else 0,
+            1 if status & NRF24.MAX_RT else 0,
+            ((status >> NRF24.RX_P_NO) & 0b111),
+            1 if status & NRF24.TX_FULL else 0)
+
+        self.print_single_status_line("STATUS", status_str)
+
+    def print_observe_tx(self, value=None):
+        if value is None:
+            value = self.read_register(NRF24.OBSERVE_TX)
+        tx_str = "0x{0:02x}: POLS_CNT={1:x} ARC_CNT={2:x}".format(
+            value,
+            (value >> NRF24.PLOS_CNT) & 0b1111,
+            (value >> NRF24.ARC_CNT) & 0b1111)
+
+        self.print_single_status_line("OBSERVE_TX", tx_str)
+
+    def print_byte_register(self, name, reg, qty=1):
+        registers = ["0x{:0>2x}".format(self.read_register(reg+r)) for r in range(0, qty)]
+        self.print_single_status_line(name, " ".join(registers))
+
+    def print_address_register(self, name, reg, qty=1):
+        address_registers = ["0x{0:>2x}{1:>2x}{2:>2x}{3:>2x}{4:>2x}".format(
+            *self.read_register(reg+r, 5))
+            for r in range(qty)]
+
+        self.print_single_status_line(name, " ".join(address_registers))
+
+    def print_details(self):
+        self.print_byte_register("CONFIG", NRF24.CONFIG)
+        self.print_byte_register("EN_AA", NRF24.EN_AA)
+        self.print_byte_register("EN_RXADDR", NRF24.EN_RXADDR)
+        self.print_byte_register("SETUP_AW", NRF24.SETUP_AW)
+        self.print_byte_register("SETUP_RETR", NRF24.SETUP_RETR)
+        self.print_byte_register("RF_CH", NRF24.RF_CH)
+        self.print_byte_register("RF_SETUP", NRF24.RF_SETUP)
+        self.print_status()
+        self.print_observe_tx()
+        self.print_address_register("RX_ADDR_P0-1", NRF24.RX_ADDR_P0, 2)
+        self.print_byte_register("RX_ADDR_P2-5", NRF24.RX_ADDR_P2, 4)
+        self.print_address_register("TX_ADDR", NRF24.TX_ADDR)
+        self.print_byte_register("RX_PW_P0-5", NRF24.RX_PW_P0, 6)
+        self.print_byte_register("FIFO_STATUS", NRF24.FIFO_STATUS)
+        self.print_byte_register("DYNPD/FEATURE", NRF24.DYNPD, 2)
+
+        self.print_single_status_line("Data Rate", '%d kbps' % self.data_rate)
+        self.print_single_status_line("Model", NRF24.model_e_str_P[self.p_variant])
+        self.print_single_status_line("CRC Length", '%d Bytes' % self.crc_length)
+        self.print_single_status_line("PA Power", '%d dBm' % self.dbm)
+
+    def start_listening(self):
+        self._check_settings()
+        self.write_register(NRF24.CONFIG, self.read_register(NRF24.CONFIG) |
+                            NRF24.PWR_UP | NRF24.PRIM_RX)
+        self.clear_irq_flags()
 
         # Restore the pipe0 address, if exists
         if self.pipe0_reading_address:
-            self.write_register(self.RX_ADDR_P0, self.pipe0_reading_address, 5)
+            self.write_register(self.RX_ADDR_P0, self.pipe0_reading_address)
 
         # Go!
-        self.ce(NRF24.HIGH)
+        self.set_ce(1)
+        # There is no need to wait for the radio to come up, as no bad things
+        # happen during this time
 
-        # wait for the radio to come up (130us actually only needed)
-        time.sleep(130 / 1000000.0)
-
-    def stopListening(self):
-        self.ce(NRF24.LOW)
+    def stop_listening(self):
+        self.set_ce(0)
         self.flush_tx()
         self.flush_rx()
 
         # Enable TX
         self.write_register(NRF24.CONFIG,
-                            (self.read_register(NRF24.CONFIG) | _BV(NRF24.PWR_UP)) & ~_BV(NRF24.PRIM_RX))
+                            (self.read_register(NRF24.CONFIG) | NRF24.PWR_UP) & ~NRF24.PRIM_RX)
 
-    def powerDown(self):
-        self.write_register(NRF24.CONFIG, self.read_register(NRF24.CONFIG) & ~_BV(NRF24.PWR_UP))
+    def power_down(self):
+        self.write_register(NRF24.CONFIG, self.read_register(NRF24.CONFIG) & ~NRF24.PWR_UP)
 
-    def powerUp(self):
-        self.write_register(NRF24.CONFIG, self.read_register(NRF24.CONFIG) | _BV(NRF24.PWR_UP))
-        time.sleep(150 / 1000000.0)
+    def power_up(self):
+        self.write_register(NRF24.CONFIG, self.read_register(NRF24.CONFIG) | NRF24.PWR_UP)
+        time.sleep(150e-6)
 
-    def write(self, buf, result=True):
-        # Begin the write
-        self.startWrite(buf)
+    def write(self, buf):
+        """ Send a data packet.
+            Returns true if the packet was transmitted sucessfully."""
+        length = self.write_payload(buf)
+        self.set_ce(1)
+        time.sleep(10e-6)
+        self.set_ce(0)
 
-        sent_at = time.time()
-        while time.time() - sent_at < self.max_timeout:
-            if (self.get_status() & (_BV(NRF24.TX_DS) | _BV(NRF24.MAX_RT))):
+        # 57 bits preamble/address, data rate is kbit/s => *1000
+        packet_time = ((length + self.crc_length_cached) * 8 + 57)/(self.data_rate_cached*1000)
+        timeout = self.retries_cached * (packet_time + self.delay*1e-6)
+        sent_at = monotonic()
+        while monotonic() - sent_at < timeout:
+            time.sleep(packet_time)
+            status = self.status()
+            if status & NRF24.TX_DS:
+                return True
+            if status & NRF24.MAX_RT:
                 break
+            time.sleep(self.delay*1e-6)
+        self.flush_tx() # Avoid leaving the payload in tx fifo
+        return False
 
-            time.sleep(self.timeout)
-
-        if not result:
-            return
-
-        what = self.whatHappened()
-
-        result = what['tx_ok']
-
-        # Handle the ack packet
-        if what['rx_ready']:
-            self.ack_payload_length = self.getDynamicPayloadSize()
-
-        return result
-
-    def startFastWrite(self, buf):
-        """
-            Do not wait for CE HIGH->LOW
-        """
-        # Send the payload
-        self.write_payload(buf)
-
-        self.ce(NRF24.HIGH)
-
-    def startWrite(self, buf):
-        # Send the payload
-        self.write_payload(buf)
-
-        # Allons!
-        self.ce(NRF24.HIGH)
-        time.sleep(0.000010)
-        self.ce(NRF24.LOW)
-
-    def getDynamicPayloadSize(self):
+    def dynamic_payload_size(self):
+        """ Read the size of the most recent packet in fifo. """
         return self.spidev.xfer2([NRF24.R_RX_PL_WID, NRF24.NOP])[1]
 
     def available(self, pipe_num=None, irq_wait=False, irq_timeout=30000):
         if not pipe_num:
             pipe_num = []
 
-        status = self.get_status()
+        status = self.status()
         result = False
 
         # Sometimes the radio specifies that there is data in one pipe but
         # doesn't set the RX flag...
-        if status & _BV(NRF24.RX_DR) or (status & 0b00001110 != 0b00001110):
+        if status & NRF24.RX_DR or (status & 0b00001110 != 0b00001110):
             result = True
         else:
             if irq_wait:  # Will use IRQ wait
-                if self.irqWait(irq_timeout):  # Do we have a packet?
-                    status = self.get_status()  # Seems like we do!
-                    if status & _BV(NRF24.RX_DR) or (status & 0b00001110 != 0b00001110):
+                if self.irq_wait(irq_timeout):  # Do we have a packet?
+                    status = self.status()  # Seems like we do!
+                    if status & NRF24.RX_DR or (status & 0b00001110 != 0b00001110):
                         result = True
 
         if result:
@@ -536,105 +466,83 @@ class NRF24:
 
                 # ??? Should this REALLY be cleared now?  Or wait until we
                 # actually READ the payload?
-        self.write_register(NRF24.STATUS, _BV(NRF24.RX_DR))
+        self.write_register(NRF24.STATUS, NRF24.RX_DR)
 
         # Handle ack payload receipt
-        if status & _BV(NRF24.TX_DS):
-            self.write_register(NRF24.STATUS, _BV(NRF24.TX_DS))
+        if status & NRF24.TX_DS:
+            self.write_register(NRF24.STATUS, NRF24.TX_DS)
 
         return result
 
-    def read(self, buf, buf_len=-1):
-        # Fetch the payload
-        self.read_payload(buf, buf_len)
+    def open_writing_pipe(self, value):
+        self.write_register(NRF24.RX_ADDR_P0, value)
+        self.write_register(NRF24.TX_ADDR, value)
+        if not self.dynamic_payloads_enabled:
+            self.write_register(NRF24.RX_PW_P0, self.payload_size_cached)
 
-        # was this the last of the data available?
-        return self.read_register(NRF24.FIFO_STATUS) & _BV(NRF24.RX_EMPTY)
-
-    def whatHappened(self):
-        # Read the status & reset the status in one easy call
-        # Or is that such a good idea?
-        status = self.write_register(NRF24.STATUS, _BV(NRF24.RX_DR) | _BV(NRF24.TX_DS) | _BV(NRF24.MAX_RT))
-
-        # Report to the user what happened
-        tx_ok = status & _BV(NRF24.TX_DS)
-        tx_fail = status & _BV(NRF24.MAX_RT)
-        rx_ready = status & _BV(NRF24.RX_DR)
-        return {'tx_ok': tx_ok, "tx_fail": tx_fail, "rx_ready": rx_ready}
-
-    def openWritingPipe(self, value):
-        # Note that the NRF24L01(+)
-        # expects it LSB first.
-
-        self.write_register(NRF24.RX_ADDR_P0, value, 0x5)
-        self.write_register(NRF24.TX_ADDR, value, 0x5)
-        self.write_register(NRF24.RX_PW_P0, min(self.payload_size, 32))
-
-    def openReadingPipe(self, child, address):
+    def open_reading_pipe(self, pipe, address):
+        if pipe >= 6:
+            raise RuntimeError("Invalid pipe number")
+        if (pipe >= 2 and len(address) > 1) or len(address) > 5:
+            raise RuntimeError("Invalid adress length")
         # If this is pipe 0, cache the address.  This is needed because
         # openWritingPipe() will overwrite the pipe 0 address, so
         # startListening() will have to restore it.
-        if child == 0:
+        if pipe == 0:
             self.pipe0_reading_address = address
+        self.write_register(NRF24.RX_ADDR_P0 + pipe, address)
 
-        if child <= 6:
-            # For pipes 2-5, only write the LSB
-            if child < 2:
-                self.write_register(NRF24.child_pipe[child], address, 0x5)
-            else:
-                self.write_register(NRF24.child_pipe[child], address, 0x1)
+        if not self.dynamic_payloads_enabled:
+            self.write_register(NRF24.RX_PW_P0 + pipe, self.payload_size_cached)
 
-            self.write_register(NRF24.child_payload_size[child], self.payload_size)
-
-            # Note it would be more efficient to set all of the bits for all open
-            # pipes at once.  However, I thought it would make the calling code
-            # more simple to do it this way.
-            self.write_register(NRF24.EN_RXADDR,
-                                self.read_register(NRF24.EN_RXADDR) | _BV(NRF24.child_pipe_enable[child]))
-
-    def closeReadingPipe(self, pipe):
+        # Note it would be more efficient to set all of the bits for all open
+        # pipes at once.  However, I thought it would make the calling code
+        # more simple to do it this way.
         self.write_register(NRF24.EN_RXADDR,
-                            self.read_register(NRF24.EN_RXADDR) & ~_BV(NRF24.child_pipe_enable[pipe]))
+                            self.read_register(NRF24.EN_RXADDR) | (1<<pipe))
+
+    def close_reading_pipe(self, pipe):
+        self.write_register(NRF24.EN_RXADDR,
+                            self.read_register(NRF24.EN_RXADDR) & ~(1<<pipe))
 
     def toggle_features(self):
         buf = [NRF24.ACTIVATE, 0x73]
         self.spidev.xfer2(buf)
 
-    def enableDynamicPayloads(self):
+    def enable_dynamic_payloads(self):
         # Enable dynamic payload throughout the system
-        self.write_register(NRF24.FEATURE, self.read_register(NRF24.FEATURE) | _BV(NRF24.EN_DPL))
+        self.write_register(NRF24.FEATURE, self.read_register(NRF24.FEATURE) | NRF24.EN_DPL)
 
         # If it didn't work, the features are not enabled
         if not self.read_register(NRF24.FEATURE):
             # So enable them and try again
             self.toggle_features()
-            self.write_register(NRF24.FEATURE, self.read_register(NRF24.FEATURE) | _BV(NRF24.EN_DPL))
+            self.write_register(NRF24.FEATURE, self.read_register(NRF24.FEATURE) | NRF24.EN_DPL)
 
         # Enable dynamic payload on all pipes
 
         # Not sure the use case of only having dynamic payload on certain
         # pipes, so the library does not support it.
-        self.write_register(NRF24.DYNPD, self.read_register(NRF24.DYNPD) | _BV(NRF24.DPL_P5) | _BV(NRF24.DPL_P4) | _BV(
-            NRF24.DPL_P3) | _BV(NRF24.DPL_P2) | _BV(NRF24.DPL_P1) | _BV(NRF24.DPL_P0))
+        self.write_register(NRF24.DYNPD, self.read_register(NRF24.DYNPD) | 0b00111111)
 
         self.dynamic_payloads_enabled = True
 
-    def enableAckPayload(self):
+    def enable_ack_payload(self):
         # enable ack payload and dynamic payload features
         self.write_register(NRF24.FEATURE,
-                            self.read_register(NRF24.FEATURE) | _BV(NRF24.EN_ACK_PAY) | _BV(NRF24.EN_DPL))
+                            self.read_register(NRF24.FEATURE) | NRF24.EN_ACK_PAY | NRF24.EN_DPL)
 
         # If it didn't work, the features are not enabled
         if not self.read_register(NRF24.FEATURE):
             # So enable them and try again
             self.toggle_features()
             self.write_register(NRF24.FEATURE,
-                                self.read_register(NRF24.FEATURE) | _BV(NRF24.EN_ACK_PAY) | _BV(NRF24.EN_DPL))
+                                self.read_register(NRF24.FEATURE) | NRF24.EN_ACK_PAY | NRF24.EN_DPL)
 
         # Enable dynamic payload on pipes 0 & 1
-        self.write_register(NRF24.DYNPD, self.read_register(NRF24.DYNPD) | _BV(NRF24.DPL_P1) | _BV(NRF24.DPL_P0))
+        self.write_register(NRF24.DYNPD, self.read_register(NRF24.DYNPD) | 0b11)
 
-    def writeAckPayload(self, pipe, buf, buf_len):
+    def write_ack_payload(self, pipe, buf, buf_len):
         txbuffer = [NRF24.W_ACK_PAYLOAD | (pipe & 0x7)]
 
         max_payload_size = 32
@@ -643,157 +551,151 @@ class NRF24:
 
         self.spidev.xfer2(txbuffer)
 
-    def isAckPayloadAvailable(self):
-        result = self.ack_payload_available
-        self.ack_payload_available = False
-        return result
-
-    def isPVariant(self):
-        return self.p_variant
-
-    def setAutoAck(self, enable):
+    def set_auto_ack(self, enable):
         if enable:
             self.write_register(NRF24.EN_AA, 0x3F)
         else:
             self.write_register(NRF24.EN_AA, 0)
 
-    def setAutoAckPipe(self, pipe, enable):
+    def set_auto_ack_pipe(self, pipe, enable):
         if pipe <= 6:
             en_aa = self.read_register(NRF24.EN_AA)
             if enable:
-                en_aa |= _BV(pipe)
+                en_aa |= 1 << pipe
             else:
-                en_aa &= ~_BV(pipe)
+                en_aa &= ~(1 << pipe)
 
             self.write_register(NRF24.EN_AA, en_aa)
 
-    def setAddressWidth(self, width):
+    def set_address_width(self, width):
         if width >= 2 and width <= 5:
             self.write_register(NRF24.SETUP_AW, width - 2)
-            self.address_width = width
+        else:
+            raise RuntimeError("Invalid address width")
 
-    def testCarrier(self):
+    def channel_active(self):
         return self.read_register(NRF24.CD) & 1
 
-    def testRPD(self):
-        return self.read_register(NRF24.RPD) & 1
+    @property
+    def dbm(self):
+        power = self.read_register(NRF24.RF_SETUP) & (NRF24.RF_PWR_LOW | NRF24.RF_PWR_HIGH)
 
-    def setPALevel(self, level):
+        if power == (NRF24.RF_PWR_LOW | NRF24.RF_PWR_HIGH):
+            return 0
+        elif power == NRF24.RF_PWR_HIGH:
+            return -6
+        elif power == NRF24.RF_PWR_LOW:
+            return -12
+        else:
+            return -18
+
+    @dbm.setter
+    def dbm(self, level):
         setup = self.read_register(NRF24.RF_SETUP)
-        setup &= ~(_BV(NRF24.RF_PWR_LOW) | _BV(NRF24.RF_PWR_HIGH))
-
-        # switch uses RAM (evil!)
-        if level == NRF24.PA_MAX:
-            setup |= (_BV(NRF24.RF_PWR_LOW) | _BV(NRF24.RF_PWR_HIGH))
-        elif level == NRF24.PA_HIGH:
-            setup |= _BV(NRF24.RF_PWR_HIGH)
-        elif level == NRF24.PA_LOW:
-            setup |= _BV(NRF24.RF_PWR_LOW)
-        elif level == NRF24.PA_MIN:
-            pass
-        elif level == NRF24.PA_ERROR:
-            # On error, go to maximum PA
-            setup |= (_BV(NRF24.RF_PWR_LOW) | _BV(NRF24.RF_PWR_HIGH))
+        setup &= ~(NRF24.RF_PWR_LOW | NRF24.RF_PWR_HIGH)
+        if level == 0:
+            setup |= NRF24.RF_PWR_LOW | NRF24.RF_PWR_HIGH
+        elif level == -6:
+            setup |= NRF24.RF_PWR_HIGH
+        elif level == -12:
+            setup |= NRF24.RF_PWR_LOW
+        elif level != -18:
+            raise RuntimeError("Invalid power level")
 
         self.write_register(NRF24.RF_SETUP, setup)
 
-    def getPALevel(self):
-        power = self.read_register(NRF24.RF_SETUP) & (_BV(NRF24.RF_PWR_LOW) | _BV(NRF24.RF_PWR_HIGH))
-
-        if power == (_BV(NRF24.RF_PWR_LOW) | _BV(NRF24.RF_PWR_HIGH)):
-            return NRF24.PA_MAX
-        elif power == _BV(NRF24.RF_PWR_HIGH):
-            return NRF24.PA_HIGH
-        elif power == _BV(NRF24.RF_PWR_LOW):
-            return NRF24.PA_LOW
+    @property
+    def data_rate(self):
+        rate = self.read_register(NRF24.RF_SETUP) & (NRF24.RF_DR_LOW | NRF24.RF_DR_HIGH)
+        if rate == NRF24.RF_DR_LOW:
+            return 250
+        elif rate == NRF24.RF_DR_HIGH:
+            return 2000
         else:
-            return NRF24.PA_MIN
+            return 1000
 
-    def setDataRate(self, speed):
-        setup = self.read_register(NRF24.RF_SETUP)
-
-        # HIGH and LOW '00' is 1Mbs - our default
-        setup &= ~(_BV(NRF24.RF_DR_LOW) | _BV(NRF24.RF_DR_HIGH))
-
-        if speed == NRF24.BR_250KBPS:
-            # Must set the RF_DR_LOW to 1 RF_DR_HIGH (used to be RF_DR) is already 0
-            # Making it '10'.
-            self.data_rate_bits = 250
-            self.data_rate = NRF24.BR_250KBPS
-
-            setup |= _BV(NRF24.RF_DR_LOW)
+    @data_rate.setter
+    def data_rate(self, speed):
+        setup = self.read_register(NRF24.RF_SETUP) & ~(NRF24.RF_DR_LOW | NRF24.RF_DR_HIGH)
+        if speed == 250:
+            setup |= NRF24.RF_DR_LOW
+        elif speed == 1000:
+            pass
+        elif speed == 2000:
+            setup |= NRF24.RF_DR_HIGH
         else:
-            # Set 2Mbs, RF_DR (RF_DR_HIGH) is set 1
-            # Making it '01'
-            if speed == NRF24.BR_2MBPS:
-                self.data_rate_bits = 2000
-                self.data_rate = NRF24.BR_2MBPS
-                setup |= _BV(NRF24.RF_DR_HIGH)
+            raise RuntimeError("Invalid data rate")
+        self.data_rate_cached = speed
+        self.write_register(NRF24.RF_SETUP, setup)
+        if self.read_register(NRF24.RF_SETUP) != setup:
+            raise RuntimeError("Datarate not supported")
+
+    @property
+    def crc_length(self):
+        config = self.read_register(NRF24.CONFIG) & (NRF24.CRCO | NRF24.EN_CRC)
+        if config & NRF24.EN_CRC:
+            if config & NRF24.CRCO:
+                return 2
             else:
-                # 1Mbs
-                self.data_rate_bits = 1000
-                self.data_rate = NRF24.BR_1MBPS
+                return 1
+        return 0
 
-        self.write_register(NRF24.RF_SETUP, setup)
-
-        # Verify our result
-        return self.read_register(NRF24.RF_SETUP) == setup
-
-    def getDataRate(self):
-        dr = self.read_register(NRF24.RF_SETUP) & (_BV(NRF24.RF_DR_LOW) | _BV(NRF24.RF_DR_HIGH))
-        # Order matters in our case below
-        if dr == _BV(NRF24.RF_DR_LOW):
-            # '10' = 250KBPS
-            return NRF24.BR_250KBPS
-        elif dr == _BV(NRF24.RF_DR_HIGH):
-            # '01' = 2MBPS
-            return NRF24.BR_2MBPS
-        else:
-            # '00' = 1MBPS
-            return NRF24.BR_1MBPS
-
-    def setCRCLength(self, length):
-        config = self.read_register(NRF24.CONFIG) & ~(_BV(NRF24.CRC_16) | _BV(NRF24.CRC_ENABLED))
-
-        if length == NRF24.CRC_DISABLED:
+    @crc_length.setter
+    def crc_length(self, length):
+        config = self.read_register(NRF24.CONFIG) & ~(NRF24.CRCO | NRF24.EN_CRC)
+        if length == 0:
             pass
-        elif length == NRF24.CRC_8:
-            config |= _BV(NRF24.CRC_ENABLED)
-            config |= _BV(NRF24.CRC_8)
+        elif length == 1:
+            config |= NRF24.EN_CRC
+        elif length == 2:
+            config |= NRF24.EN_CRC | NRF24.CRCO
         else:
-            config |= _BV(NRF24.CRC_ENABLED)
-            config |= _BV(NRF24.CRC_16)
-
+            raise RuntimeError("Invalid CRC length")
+        self.crc_length_cached = length
         self.write_register(NRF24.CONFIG, config)
 
-    def getCRCLength(self):
-        result = NRF24.CRC_DISABLED
-        config = self.read_register(NRF24.CONFIG) & (_BV(NRF24.CRCO) | _BV(NRF24.EN_CRC))
+    @property
+    def channel(self):
+        return self.read_register(NRF24.RF_CH)
 
-        if config & _BV(NRF24.EN_CRC):
-            if config & _BV(NRF24.CRCO):
-                result = NRF24.CRC_16
-            else:
-                result = NRF24.CRC_8
+    @channel.setter
+    def channel(self, channel):
+        if channel < 0 or channel > self.MAX_CHANNEL:
+            raise RuntimeError("Channel number out of range")
+        self.channel_cached = channel
+        self.write_register(NRF24.RF_CH, channel)
 
-        return result
+    @property
+    def payload_size(self):
+        return self.payload_size_cached
 
-    def disableCRC(self):
-        disable = self.read_register(NRF24.CONFIG) & ~_BV(NRF24.EN_CRC)
-        self.write_register(NRF24.CONFIG, disable)
+    @payload_size.setter
+    def payload_size(self, size):
+        if size < 1 or size > self.MAX_PAYLOAD_SIZE:
+            raise RuntimeError("Payload size of of range")
+        # Size is set in open_reading_pipe()
+        self.payload_size_cached = size
 
-    def setRetries(self, delay, count):
-        self.write_register(NRF24.SETUP_RETR, (delay & 0xf) << NRF24.ARD | (count & 0xf) << NRF24.ARC)
-        self.delay = delay * 0.000250
-        self.retries = count
-        self.max_timeout = (self.payload_size / float(self.data_rate_bits) + self.delay) * self.retries
-        self.timeout = (self.payload_size / float(self.data_rate_bits) + self.delay)
 
-    def getRetries(self):
+
+    def set_retries(self, delay, count):
+        if delay % 250 != 0:
+            raise RuntimeError("Delay can only be specified in increments of 250µs")
+        if delay < 250 or delay > 4000:
+            raise RuntimeError("Invalid delay")
+        if count < 0 or count > 15:
+            raise RuntimeError("Invalid count")
+        self.write_register(NRF24.SETUP_RETR, ((delay // 250)-1) << NRF24.ARD | count << NRF24.ARC)
+        self.delay = delay
+        self.retries_cached = count
+
+    def raw_retries(self):
         return self.read_register(NRF24.SETUP_RETR)
 
-    def getMaxTimeout(self):
-        return self.max_timeout
-
-    def getTimeout(self):
-        return self.timeout
+    def _check_settings(self):
+        if self.data_rate_cached is None:
+            raise RuntimeError("No data rate specified")
+        if self.crc_length_cached is None:
+            raise RuntimeError("No CRC length specified")
+        if self.channel_cached is None:
+            raise RuntimeError("No channel specified")

--- a/nrf24.py
+++ b/nrf24.py
@@ -426,6 +426,7 @@ class NRF24(object):
     def write(self, buf):
         """ Send a data packet.
             Returns true if the packet was transmitted sucessfully."""
+        self.clear_irq_flags()
         self.last_error = None
         length = self.write_payload(buf)
         self.set_ce(1)

--- a/nrf24.py
+++ b/nrf24.py
@@ -244,7 +244,7 @@ class NRF24:
             if length < 0:
                 length = len(value)
 
-            for i in xrange(min(len(value), length)):
+            for i in range(min(len(value), length)):
                 buf.append(int(value[len(value) - i - 1] & 0xff))
         else:
             raise Exception("Value must be int or list")


### PR DESCRIPTION
The SPI device is not initialized correctly. In my case SPI mode was set to 3 by default and lead to corrupted data transfers. This patch initializes all parameters with correct values. 