### PR TITLE
Explicitly define timeout parameter in irqWait

### DIFF
--- a/nrf24.py
+++ b/nrf24.py
@@ -333,7 +333,7 @@ class NRF24:
             return True
 
         try:
-            return GPIO.wait_for_edge(self.irq_pin, GPIO.FALLING, timeout) == 1
+            return GPIO.wait_for_edge(self.irq_pin, GPIO.FALLING, timeout=timeout) == 1
         except TypeError:  # Timeout parameter not supported
             return GPIO.wait_for_edge(self.irq_pin, GPIO.FALLING) == 1
         except AttributeError:


### PR DESCRIPTION
Currently, the `timeout` parameter in irqWait passes improperly to the call to `GPIO.wait_for_edge`, setting the `bouncetime` parameter instead. This causes the example `recv.py` script to fail, as packets sent more frequently than the `bouncetime` setting (30 seconds by default) cause the IRQ pin to go low without being caught by the `GPIO.wait_for_edge`, which completely hangs the script.
This is easily fixed by specifying the parameter name explicitly.